### PR TITLE
Fixed Daenerys' full image url

### DIFF
--- a/data/characters.json
+++ b/data/characters.json
@@ -676,7 +676,7 @@
          "characterName":"Daenerys Targaryen",
          "houseName":"Targaryen",
          "characterImageThumb":"https://images-na.ssl-images-amazon.com/images/M/MV5BMjA4MzIxMTQwMF5BMl5BanBnXkFtZTcwMzY2NDg1Nw@@._V1._SX100_SY140_.jpg",
-         "characterImageFull":"https://images-na.ssl-images-amazon.com/images/M/MV5BMjA4MzIxMTQwMF5BMl5BanBnXkFtZTcwMzY2NDg1Nw@@._V1_SY1000_CR0,0,810,1000_AL_.jpghttps://images-na.ssl-images-amazon.com/images/M/MV5BMTgwNzIxMTU1OV5BMl5BanBnXkFtZTcwNzI2ODg5NA@@._V1._SX100_SY140_.jpg",
+         "characterImageFull":"https://images-na.ssl-images-amazon.com/images/M/MV5BMjA4MzIxMTQwMF5BMl5BanBnXkFtZTcwMzY2NDg1Nw@@._V1_SY1000_CR0,0,810,1000_AL_.jpg",
          "characterLink":"/character/ch0158597/",
          "actorName":"Emilia Clarke",
          "actorLink":"/name/nm3592338/",


### PR DESCRIPTION
It had the thumb image url right after the full one which made the thumb load instead of the full.